### PR TITLE
Review suggestions

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -186,7 +186,7 @@ func ResolveCommonConfig(commonFlags *CommonFlags, beforeRevStr string) (*Common
 		AnalysisCacheClearStrategy:             *commonFlags.AnalysisCacheClearStrategy,
 		CompareQueriesAroundAnalysisCacheClear: commonFlags.CompareQueriesAroundAnalysisCacheClear,
 		FilterIncompatibleTargets:              commonFlags.FilterIncompatibleTargets,
-		EnforceCleanRepo: 					 	commonFlags.EnforceCleanRepo == EnforceClean,
+		EnforceCleanRepo:                       commonFlags.EnforceCleanRepo == EnforceClean,
 	}
 
 	// Non-context attributes

--- a/pkg/target_determinator.go
+++ b/pkg/target_determinator.go
@@ -378,7 +378,7 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 	}
 	if !isPreCheckoutClean {
 		if context.EnforceCleanRepo {
-			return "", fmt.Errorf("pre-checkout repository is not clean")
+			return "", fmt.Errorf("repository was not clean before checking out %v", rev)
 		}
 
 		log.Printf("Workspace is unclean, using git worktree. This will be slower the first time. " +
@@ -395,7 +395,7 @@ func gitSafeCheckout(context *Context, rev LabelledGitRev, ignoredFiles []common
 		}
 		if !isPostCheckoutClean {
 			if context.EnforceCleanRepo {
-				return "", fmt.Errorf("post-checkout repository is not clean")
+				return "", fmt.Errorf("repository was not clean after checking out %v", rev)
 			}
 
 			log.Printf("Detected unclean repository after checkout (likely due to submodule or " +

--- a/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
+++ b/tests/integration/java/com/github/bazel_contrib/target_determinator/integration/Tests.java
@@ -673,6 +673,7 @@ class Commits {
       "c0ef0f9805e65817299eb7a794ed66655c0dd5aa";
   public static final String REDUCE_DEPENDENCY_VISIBILITY =
       "396dae111684b893ec6e04b2f6e86ed603a01082";
+  public static final String ONE_TEST_WITH_GITIGNORE = "51bf9b729dddf35694019c19b5dbffb36bf83af4";
   public static final String TWO_TESTS_WITH_GITIGNORE = "55845a3a08525f2aa66c3d7a2115dad684c46995";
   public static final String SUBMODULE_ADD_TRIVIAL_SUBMODULE =
       "b88ddcfe3da63c8308ce6d3274dd424d2c7b211a";


### PR DESCRIPTION
* Make the error message less ambiguous, because "pre-checkout" and "post-checkout" may be misread to refer to "the before commit" and "the after commit" rather than "after checking out the before commit".
* Add test which shows that if a file is consistently .gitignore'd before and after, it will continue to work.